### PR TITLE
사전 기능을 수정하였습니다.

### DIFF
--- a/src/main/java/org/apache/lucene/analysis/ko/utils/DictionaryUtil.java
+++ b/src/main/java/org/apache/lucene/analysis/ko/utils/DictionaryUtil.java
@@ -68,6 +68,19 @@ public class DictionaryUtil {
   }
   
   /**
+   * 단어 사전을 로드하지 않는다.
+   * 
+   * @throws MorphException
+   */
+  public static void initDictionary() throws MorphException {
+	if (!initialized.get()) initialize();  
+	synchronized(prepared) {
+		DictionaryUtil.dictionary = new Trie<String, WordEntry>(true);
+	    prepared.set(true);
+	}
+  }
+  
+  /**
    * 사전이 준비되었는지 확인
    */
   private static void checkDictionary() throws MorphException {
@@ -247,6 +260,58 @@ public class DictionaryUtil {
       } catch (MorphException e) {
           throw new RuntimeException(e);
       }
+  }
+  
+  /**
+   * Thread Safe 하지 않음
+   * @Experimental 
+   */
+  public static void clearWords() {
+	  if (dictionary != null) {
+		  dictionary.clear();
+	  }
+  }
+  
+  /**
+   * Thread Safe 하지 않음
+   * @Experimental 
+   */
+  public static void addWord(WordEntry entry) {
+	  synchronized(prepared) {
+		  if (dictionary == null) {
+			 dictionary = new Trie<String, WordEntry>(true);
+		  }
+		  dictionary.add(entry.getWord(), entry);
+		  prepared.set(true);
+	  }
+  }
+  
+  /**
+   * Thread Safe 하지 않음 
+   * @Experimental
+   */
+  public static void addWords(List<String> lines) {
+	  synchronized(prepared) {
+		  if (dictionary == null) {
+			 dictionary = new Trie<String, WordEntry>(true);
+		  }
+		  loadWords(dictionary, lines);
+		  prepared.set(true);
+	  }
+  }
+  
+  /**
+   * Thread Safe 하지 않음 
+   * @Experimental
+   */
+  public static void addCompounds(List<String> lines) {
+	  synchronized(prepared) {
+		  if (dictionary == null) {
+			 dictionary = new Trie<String, WordEntry>(true);
+		  }
+		  loadCompounds(dictionary, lines);
+		  prepared.set(true);
+	  }
   }
 
   public static WordEntry getWordExceptVerb(String key) throws MorphException {    

--- a/src/main/java/org/apache/lucene/analysis/ko/utils/DictionaryUtil.java
+++ b/src/main/java/org/apache/lucene/analysis/ko/utils/DictionaryUtil.java
@@ -1,5 +1,13 @@
 package org.apache.lucene.analysis.ko.utils;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -21,12 +29,6 @@ import org.apache.lucene.analysis.ko.morph.CompoundEntry;
 import org.apache.lucene.analysis.ko.morph.MorphException;
 import org.apache.lucene.analysis.ko.morph.WordEntry;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-
 public class DictionaryUtil {
   
   private static Trie<String,WordEntry> dictionary;
@@ -45,28 +47,65 @@ public class DictionaryUtil {
   
   private static HashMap<String, String> abbreviations;
   
+  private static List<char[]> syllables;  // 음절특성 정보
+  
+  private static AtomicBoolean initialized = new AtomicBoolean(); // 조사,어미 등..
+  private static AtomicBoolean prepared = new AtomicBoolean(); // 단어사전(dictionary)이 준비되었는가?
+  
   /**
-   * 사전을 로드한다.
+   * 기존 로드 방식을 유지하기 위해서, 
+   * Elasticsearch 플러그인의 reload를 위해서 단어는 무조건 리로드
+   * @throws MorphException
    */
-  public synchronized static void loadDictionary() throws MorphException {
-    
-    dictionary = new Trie<String, WordEntry>(true);
-    List<String> strList = null;
-    List<String> compounds = null;
-    List<String> abbrevs = null;
-    try {
-      strList = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_DICTIONARY),"UTF-8");
-      strList.addAll(FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_EXTENSION),"UTF-8"));
-      compounds = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_COMPOUNDS),"UTF-8"); 
-      abbrevs = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_ABBREV),"UTF-8"); 
-    } catch (IOException e) {      
-      new MorphException(e.getMessage(),e);
-    } catch (Exception e) {
-      new MorphException(e.getMessage(),e);
-    }
-    if(strList==null) throw new MorphException("dictionary is null");;
-    
-    for(String str:strList) {
+  public static void loadDictionary() throws MorphException {
+	if (!initialized.get()) initialize();
+	loadWordsAndCompounds(true); // 
+  }
+  
+  public static void loadDictionary(boolean reload) throws MorphException {
+	if (!initialized.get()) initialize();
+	loadWordsAndCompounds(reload); 
+  }
+  
+  /**
+   * 사전이 준비되었는지 확인
+   */
+  private static void checkDictionary() throws MorphException {
+	if(!initialized.get()) initialize();
+	if(!prepared.get()) loadWordsAndCompounds(false);
+  }
+  
+  private static void loadWordsAndCompounds(boolean reload) throws MorphException {
+	synchronized(prepared) {
+	  if (!reload && prepared.get())
+		return;
+	  
+	  long start = System.currentTimeMillis();
+	  try {
+	    Trie<String, WordEntry> dictionary = new Trie<String, WordEntry>(true);
+	    List<String> strList = null;
+	    List<String> compounds = null;
+	    strList = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_DICTIONARY),"UTF-8");
+	    strList.addAll(FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_EXTENSION),"UTF-8"));
+	    compounds = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_COMPOUNDS),"UTF-8"); 
+	       
+	    loadWords(dictionary, strList);
+	    loadCompounds(dictionary, compounds);
+	
+	    DictionaryUtil.dictionary = dictionary;
+	    prepared.set(true);
+	    Logger.getLogger("org.apache.lucene.analysis.ko.Dictionary")
+	      .info("단어사전 로드 " + (System.currentTimeMillis() - start) + "ms");
+	  } catch (IOException e) {      
+	    throw new MorphException(e.getMessage(),e);
+	  } catch (Exception e) {
+	    throw new MorphException(e.getMessage(),e);
+	  }
+	}
+  }
+
+  private static void loadWords(Trie<String, WordEntry> dictionary, List<String> strList) {
+	for(String str:strList) {
       String[] infos = str.split("[,]+");
       if(infos.length!=2) continue;
       infos[1] = infos[1].trim();
@@ -75,8 +114,10 @@ public class DictionaryUtil {
       WordEntry entry = new WordEntry(infos[0].trim(),infos[1].trim().toCharArray());
       dictionary.add(entry.getWord(), entry);
     }
-    
-    for(String compound: compounds) 
+  }
+  
+  private static void loadCompounds(Trie<String, WordEntry> dictionary, List<String> compounds) {
+	for(String compound: compounds) 
     {    
       String[] infos = compound.split("[:]+");
       if(infos.length!=3&&infos.length!=2) continue;
@@ -90,27 +131,106 @@ public class DictionaryUtil {
       entry.setCompounds(compoundArrayToList(infos[1], infos[1].split("[,]+")));
       dictionary.add(entry.getWord(), entry);
     }
-    
-    abbreviations = new HashMap();
-    
-    for(String abbrev: abbrevs) 
-    {    
-      String[] infos = abbrev.split("[:]+");
-      if(infos.length!=2) continue;      
-      abbreviations.put(infos[0].trim(), infos[1].trim());
-    }
   }
+  
+  /**
+   * 단어 사전을 제외하고 기본 사전을 로드. 한번만 로드한다.
+   * @throws MorphException
+   */
+  private static void initialize() throws MorphException {
+	synchronized (initialized) {
+	  if (initialized.get())
+	    return;
+	  
+	  HashMap<String, String> abbreviations;
+	  HashMap<String, String> josas;
+	  HashMap<String, String> eomis;
+	  HashMap<String, String> prefixs;
+	  HashMap<String, String> suffixs;
+	  HashMap<String,WordEntry> uncompounds;
+	  HashMap<String, String> cjwords;
+	  
+	  long start = System.currentTimeMillis();
+	  try {
+		List<String> abbrevs = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_ABBREV),"UTF-8");
+		   
+		abbreviations = new HashMap<String, String>();
+		for(String abbrev: abbrevs) 
+		{    
+		  String[] infos = abbrev.split("[:]+");
+		  if(infos.length!=2) continue;      
+		  abbreviations.put(infos[0].trim(), infos[1].trim());
+		}
+		  
+	      
+	    josas = new HashMap<String, String>();
+	    readFile(josas,KoreanEnv.FILE_JOSA);
+	
+	    eomis = new HashMap<String, String>();
+	    readFile(eomis,KoreanEnv.FILE_EOMI);
+	    
+	    prefixs = new HashMap<String, String>();
+	    readFile(prefixs,KoreanEnv.FILE_PREFIX);
+	    
+	    suffixs = new HashMap<String, String>();
+	    readFile(suffixs,KoreanEnv.FILE_SUFFIX);
+	    
+	    cjwords = new HashMap<String, String>();
+        List<String> lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_CJ),"UTF-8");  
+        for(String cj: lines) {    
+          String[] infos = cj.split("[:]+");
+          if(infos.length!=2) continue;
+          cjwords.put(infos[0], infos[1]);
+        }      
+        
+        uncompounds = new HashMap<String,WordEntry>();
+        List<String> lines2 = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_UNCOMPOUNDS),"UTF-8");  
+        for(String compound: lines2) {    
+          String[] infos = compound.split("[:]+");
+          if(infos.length!=2) continue;
+          WordEntry entry = new WordEntry(infos[0].trim(),"90000X".toCharArray());
+          entry.setCompounds(compoundArrayToList(infos[1], infos[1].split("[,]+")));
+          uncompounds.put(entry.getWord(), entry);
+        }
+        
+    	//음절정보특성 SyllableUtil
+        ArrayList<char[]> syllables = new ArrayList<char[]>();
 
-  @SuppressWarnings({"rawtypes","unchecked"})
+        List<String> line = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_SYLLABLE_FEATURE),"UTF-8");  
+        for(int i=0;i<line.size();i++) {        
+          if(i!=0)
+        	syllables.add(line.get(i).toCharArray());
+        }
+        
+	    DictionaryUtil.abbreviations = abbreviations;
+	    DictionaryUtil.josas = josas;
+	    DictionaryUtil.eomis = eomis;
+	    DictionaryUtil.prefixs = prefixs;
+	    DictionaryUtil.suffixs = suffixs;
+	    DictionaryUtil.uncompounds = uncompounds;
+	    DictionaryUtil.cjwords = cjwords;
+	    DictionaryUtil.syllables = syllables;
+	      
+	    initialized.set(true);
+	    
+	    Logger.getLogger("org.apache.lucene.analysis.ko.Dictionary")
+	      .info("기본사전 로드 " + (System.currentTimeMillis() - start) + "ms");
+	  } catch (IOException e) {
+	    throw new MorphException(e);
+	  }
+	}
+  }
+  
+  @SuppressWarnings("unchecked")
   public static Iterator<WordEntry> findWithPrefix(String prefix) throws MorphException {
-    if(dictionary==null) loadDictionary();
+	checkDictionary();
     return dictionary.getPrefixedBy(prefix);
   }
 
   public static WordEntry getWord(String key)  {    
    
 	try {
-		if(dictionary==null) loadDictionary();
+		checkDictionary();
 	    if(key.length()==0) return null;
 	    
 	    return (WordEntry)dictionary.get(key);
@@ -119,11 +239,11 @@ public class DictionaryUtil {
 	}
 
   }
-
+  
   public static void addEntry(WordEntry entry) {
       try {
-           if(dictionary==null) loadDictionary();
-           dictionary.add(entry.getWord(), entry);
+    	  checkDictionary();
+          dictionary.add(entry.getWord(), entry);
       } catch (MorphException e) {
           throw new RuntimeException(e);
       }
@@ -177,6 +297,7 @@ public class DictionaryUtil {
     return null;
   }
   
+  @Deprecated
   public static WordEntry getAdverb(String key) throws MorphException {
     WordEntry entry = getWord(key);
     if(entry==null) return null;
@@ -185,6 +306,7 @@ public class DictionaryUtil {
     return null;
   }
   
+  @Deprecated
   public static WordEntry getBusa(String key) throws MorphException {
     WordEntry entry = getWord(key);
     if(entry==null) return null;
@@ -193,6 +315,7 @@ public class DictionaryUtil {
     return null;
   }
   
+  @Deprecated
   public static WordEntry getIrrVerb(String key, char irrType) throws MorphException {
     WordEntry entry = getWord(key);
     if(entry==null) return null;
@@ -202,6 +325,7 @@ public class DictionaryUtil {
     return null;
   }
   
+  @Deprecated
   public static WordEntry getBeVerb(String key) throws MorphException {
     WordEntry entry = getWord(key);
     if(entry==null) return null;
@@ -210,6 +334,7 @@ public class DictionaryUtil {
     return null;
   }
   
+  @Deprecated
   public static WordEntry getDoVerb(String key) throws MorphException {
     WordEntry entry = getWord(key);
     if(entry==null) return null;
@@ -219,104 +344,57 @@ public class DictionaryUtil {
   }
   
   public static String getAbbrevMorph(String key) throws MorphException {
-    if(abbreviations==null) loadDictionary();    
+	if(!initialized.get()) initialize();
+	  
     return abbreviations.get(key);
   }
   
-  public synchronized static WordEntry getUncompound(String key) throws MorphException {
-    
-    try {
-      if(uncompounds==null) {
-        uncompounds = new HashMap<String,WordEntry>();
-        List<String> lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_UNCOMPOUNDS),"UTF-8");  
-        for(String compound: lines) {    
-          String[] infos = compound.split("[:]+");
-          if(infos.length!=2) continue;
-          WordEntry entry = new WordEntry(infos[0].trim(),"90000X".toCharArray());
-          entry.setCompounds(compoundArrayToList(infos[1], infos[1].split("[,]+")));
-          uncompounds.put(entry.getWord(), entry);
-        }      
-      }  
-    }catch(Exception e) {
-      throw new MorphException(e);
-    }
+  public static WordEntry getUncompound(String key) throws MorphException {
+	if(!initialized.get()) initialize();
+	
     return uncompounds.get(key);
   }
   
-  public synchronized static String getCJWord(String key) throws MorphException {
-    
-    try {
-      if(cjwords==null) {
-        cjwords = new HashMap<String, String>();
-        List<String> lines = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_CJ),"UTF-8");  
-        for(String cj: lines) {    
-          String[] infos = cj.split("[:]+");
-          if(infos.length!=2) continue;
-          cjwords.put(infos[0], infos[1]);
-        }      
-      }  
-    }catch(Exception e) {
-      throw new MorphException(e);
-    }
+  public static String getCJWord(String key) throws MorphException {
+	if(!initialized.get()) initialize();
+	
     return cjwords.get(key);
-    
   }
   
   public static boolean existJosa(String str) throws MorphException {
-    if(josas==null) {
-      josas = new HashMap<String, String>();
-      readFile(josas,KoreanEnv.FILE_JOSA);
-    }  
-    if(josas.get(str)==null) return false;
-    else return true;
+	if(!initialized.get()) initialize();
+	  
+    return josas.containsKey(str);
   }
   
   public static boolean existEomi(String str)  throws MorphException {
-    if(eomis==null) {
-      eomis = new HashMap<String, String>();
-      readFile(eomis,KoreanEnv.FILE_EOMI);
-    }
+	if(!initialized.get()) initialize();
 
-    if(eomis.get(str)==null) return false;
-    else return true;
+    return eomis.containsKey(str);
   }
   
   public static String getJosa(String str) throws MorphException {
-    if(josas==null) {
-      josas = new HashMap<String, String>();
-      readFile(josas,KoreanEnv.FILE_JOSA);
-    }  
+	if(!initialized.get()) initialize();
+	
     return josas.get(str);
   }
   
   public static String getEomi(String str)  throws MorphException {
-    if(eomis==null) {
-      eomis = new HashMap<String, String>();
-      readFile(eomis,KoreanEnv.FILE_EOMI);
-    }
+	if(!initialized.get()) initialize();
 
     return eomis.get(str);
   }
 	  
   public static boolean existPrefix(String str)  throws MorphException {
-    if(prefixs==null) {
-      prefixs = new HashMap<String, String>();
-      readFile(prefixs,KoreanEnv.FILE_PREFIX);
-    }
+	if(!initialized.get()) initialize();
     
-    if(prefixs.get(str)==null) return false;
-    else return true;
+    return prefixs.get(str) != null;
   }
   
   public static boolean existSuffix(String str)  throws MorphException {
-    if(suffixs==null) {
-      suffixs = new HashMap<String, String>();
-      readFile(suffixs,KoreanEnv.FILE_SUFFIX);
-    }
+    if(!initialized.get()) initialize();
 
-    if(suffixs.get(str)!=null) return true;
-    
-    return false;
+    return suffixs.containsKey(str);
   }
   
   /**
@@ -344,7 +422,7 @@ public class DictionaryUtil {
    * @param dic  1: josa, 2: eomi
    * @throws MorphException excepton
    */
-  private static synchronized void readFile(HashMap<String, String> map, String dic) throws MorphException {    
+  private static void readFile(HashMap<String, String> map, String dic) throws MorphException {    
     
     String path = KoreanEnv.getInstance().getValue(dic);
 
@@ -376,5 +454,22 @@ public class DictionaryUtil {
       list.add(ce);
     }
     return list;
+  }
+
+/**
+   * 인덱스 값에 해당하는 음절의 특성을 반환한다.
+   * 영자 또는 숫자일 경우는 모두 해당이 안되므로 가장 마지막 글자인 '힣' 의 음절특성을 반환한다.
+   * 
+   * @param idx '가'(0xAC00)이 0부터 유니코드에 의해 한글음절을 순차적으로 나열한 값
+   * @throws MorphException throw exceptioin
+   */
+  public static char[] getFeature(int idx)  throws MorphException {
+	if(!initialized.get()) initialize();
+	
+    if(idx<0||idx>=syllables.size()) 
+      return syllables.get(syllables.size()-1);
+    else 
+      return syllables.get(idx);
+    
   }
 }

--- a/src/main/java/org/apache/lucene/analysis/ko/utils/FileUtil.java
+++ b/src/main/java/org/apache/lucene/analysis/ko/utils/FileUtil.java
@@ -23,6 +23,7 @@ import java.io.*;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * file utility class
@@ -39,7 +40,7 @@ public class FileUtil {
    * @throws MorphException Thrown if the classloader can not be found or if
    *  the file can not be found in the classpath.
    */
-  public static File getClassLoaderFile(String filename) throws MorphException  {
+  public static File getClassLoaderFile(String filename) {
     // note that this method is used when initializing logging, so it must
     // not attempt to log anything.
     File file = null;
@@ -48,9 +49,11 @@ public class FileUtil {
     if (url == null) {
       url = ClassLoader.getSystemResource(filename);
       if (url == null) {
-        throw new MorphException("Unable to find " + filename);
+        // throw new MorphException("Unable to find " + filename);
+    	Logger.getLogger("org.apache.lucene.analysis.ko.dic").warning("Unable to find " + filename);
+      } else {
+        file = toFile(url);
       }
-      file = toFile(url);
     } else {
       file = toFile(url);
     }
@@ -93,14 +96,16 @@ public class FileUtil {
    * @throws java.io.UnsupportedEncodingException if the encoding is not supported by the VM
    * @since Commons IO 1.1
    */
-  public static List<String> readLines(String fName, String encoding) throws MorphException, IOException  {
+  public static List<String> readLines(String fName, String encoding) throws IOException  {
     InputStream in = null;        
     try {
 
       File file = getClassLoaderFile(fName);
       if(file!=null&&file.exists()) {
+    	  Logger.getLogger("org.apache.lucene.analysis.ko.dic").info("사전[" + fName + "]을 파일[" + file.getAbsolutePath() + "]에서 로드");
         in = openInputStream(file);
       } else {
+    	  Logger.getLogger("org.apache.lucene.analysis.ko.dic").info("사전[" + fName + "]을 기본 jar에서 로드");
         in = new ByteArrayInputStream(readByteFromCurrentJar(fName));
       }
         
@@ -265,15 +270,15 @@ public class FileUtil {
     }
   }
 
-  public static byte[] readByteFromCurrentJar(String resource) throws MorphException {
+  public static byte[] readByteFromCurrentJar(String resource) {
 
     String  jarPath = FileUtil.class.getProtectionDomain().getCodeSource().getLocation().getPath();
 
     JarResources jar = new JarResources(jarPath);
-    try {  
+//    try {  
       return jar.getResource(resource);
-    } catch (Exception e) {
-      throw new MorphException(e.getMessage(),e);
-    }
+//    } catch (Exception e) {
+//      throw new MorphException(e.getMessage(),e);
+//    }
   }
 }

--- a/src/main/java/org/apache/lucene/analysis/ko/utils/SyllableUtil.java
+++ b/src/main/java/org/apache/lucene/analysis/ko/utils/SyllableUtil.java
@@ -19,10 +19,6 @@ package org.apache.lucene.analysis.ko.utils;
 
 import org.apache.lucene.analysis.ko.morph.MorphException;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 public class SyllableUtil {
 
   public static int IDX_JOSA1 = 0; // 조사의 첫음절로 사용되는 음절 49개
@@ -71,26 +67,6 @@ public class SyllableUtil {
   
   public static int IDX_EOGAN = 39; // 어미 또는 어미의 변형으로 존재할 수 있는 음 (즉 IDX_EOMI 이거나 IDX_YNPNA 이후에 1이 있는 음절)
   
-  private static List<char[]> Syllables;  // 음절특성 정보
-  
-  /**
-   * 인덱스 값에 해당하는 음절의 특성을 반환한다.
-   * 영자 또는 숫자일 경우는 모두 해당이 안되므로 가장 마지막 글자인 '힣' 의 음절특성을 반환한다.
-   * 
-   * @param idx '가'(0xAC00)이 0부터 유니코드에 의해 한글음절을 순차적으로 나열한 값
-   * @throws MorphException throw exceptioin
-   */
-  public static char[] getFeature(int idx)  throws MorphException {
-    
-    if(Syllables==null || Syllables.size()<1) Syllables = getSyllableFeature();
-  
-    if(idx<0||idx>=Syllables.size()) 
-      return Syllables.get(Syllables.size()-1);
-    else 
-      return Syllables.get(idx);
-    
-  }
-  
   /**
    * 각 음절의 특성을 반환한다.
    * @param syl  음절 하나
@@ -99,36 +75,14 @@ public class SyllableUtil {
   public static char[] getFeature(char syl) throws MorphException {
     
     int idx = syl - 0xAC00;
-    char[] feature = getFeature(idx);
+    char[] feature = DictionaryUtil.getFeature(idx);
     if(feature==null) {
-    	feature = getFeature(0);
+    	feature = DictionaryUtil.getFeature(0);
     }
     
     return feature;
     
   }
-  
-  /**
-   * 음절정보특성을 파일에서 읽는다.
-   * 
-   * @throws MorphException throw exception
-   */  
-  private static List<char[]> getSyllableFeature() throws MorphException {
-  
-    try{
-      Syllables = new ArrayList<char[]>();
-
-      List<String> line = FileUtil.readLines(KoreanEnv.getInstance().getValue(KoreanEnv.FILE_SYLLABLE_FEATURE),"UTF-8");  
-      for(int i=0;i<line.size();i++) {        
-        if(i!=0)
-          Syllables.add(line.get(i).toCharArray());
-      }
-    }catch(IOException e) {
-      throw new MorphException(e.getMessage());
-    } 
-
-    return Syllables;
-  }  
   
   public static boolean isAlpanumeric(char ch) {
     return (ch>='0'&&ch<='z');

--- a/src/test/java/org/apache/lucene/analysis/ko/DictionaryUtilTest.java
+++ b/src/test/java/org/apache/lucene/analysis/ko/DictionaryUtilTest.java
@@ -1,0 +1,46 @@
+package org.apache.lucene.analysis.ko;
+
+import org.apache.lucene.analysis.ko.morph.MorphException;
+import org.apache.lucene.analysis.ko.utils.DictionaryUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.lucene.analysis.ko.MorphAnalyzerMultiThreadTest.analyze;
+
+import java.util.Collections;
+import java.util.logging.Logger;
+
+public class DictionaryUtilTest {
+
+	private Logger log = Logger.getLogger(getClass().getName());
+
+	@Test
+	public void testAddWords() throws MorphException {
+		DictionaryUtil.loadDictionary(false);
+
+		String TEST = "저작자는 저작물을 창작한 자를 말한다";
+		String[] crumb = TEST.split("\\s+");
+
+		Assert.assertNull(DictionaryUtil.getWord("말한다"));
+		Assert.assertEquals(
+				"[저작자(N),는(j)][저작물(N),을(j)][창작(N),하(t),ㄴ(e)][자(V),를(e), 자르(V),ㄹ(e), 자(N),를(j)][말(N),하(t),ㄴ다(e)]",
+				analyze(crumb));
+
+		DictionaryUtil.addWords(Collections.singletonList("말한다,100000000X"));
+		Assert.assertNotNull(DictionaryUtil.getWord("말한다"));
+		Assert.assertEquals(
+				"[저작자(N),는(j)][저작물(N),을(j)][창작(N),하(t),ㄴ(e)][자(V),를(e), 자르(V),ㄹ(e), 자(N),를(j)][말한다(N), 말(N),하(t),ㄴ다(e)]",
+				analyze(crumb));
+		
+		DictionaryUtil.clearWords();
+		Assert.assertNull(DictionaryUtil.getWord("저작자"));
+		Assert.assertNull(DictionaryUtil.getWord("저작물"));
+		Assert.assertNull(DictionaryUtil.getWord("창작"));
+		Assert.assertNull(DictionaryUtil.getWord("자"));
+		Assert.assertNull(DictionaryUtil.getWord("말한다"));
+		//log.info(analyze(crumb));
+		Assert.assertEquals(
+				"[저작자(N),는(j), 저작자는(N)][저작물(N),을(j), 저작물을(N)][창작(N),하(t),ㄴ(e), 창작한(N)][자(N),를(j), 자를(N)][말(N),하(t),ㄴ다(e), 말한다(N)]",
+				analyze(crumb));
+	}
+}

--- a/src/test/java/org/apache/lucene/analysis/ko/EmptyDictionaryTest.java
+++ b/src/test/java/org/apache/lucene/analysis/ko/EmptyDictionaryTest.java
@@ -1,0 +1,47 @@
+package org.apache.lucene.analysis.ko;
+
+import static org.apache.lucene.analysis.ko.MorphAnalyzerMultiThreadTest.analyze;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+import org.apache.lucene.analysis.ko.morph.MorphException;
+import org.apache.lucene.analysis.ko.utils.DictionaryUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EmptyDictionaryTest {
+
+	private Logger log = Logger.getLogger(getClass().getName());
+
+	@Test
+	public void testAddWords() throws MorphException {
+		DictionaryUtil.initDictionary();
+
+		String TEST = "저작자는 저작물을 창작한 자를 말한다";
+		String[] crumb = TEST.split("\\s+");
+
+		Assert.assertNull(DictionaryUtil.getWord("저작자"));
+		Assert.assertNull(DictionaryUtil.getWord("저작물"));
+		Assert.assertNull(DictionaryUtil.getWord("창작"));
+		Assert.assertNull(DictionaryUtil.getWord("자"));
+		// log.info(analyze(crumb));
+		Assert.assertEquals(
+				"[저작자(N),는(j), 저작자는(N)][저작물(N),을(j), 저작물을(N)][창작(N),하(t),ㄴ(e), 창작한(N)][자(N),를(j), 자를(N)][말(N),하(t),ㄴ다(e), 말한다(N)]",
+				analyze(crumb));
+
+		DictionaryUtil.addWords(Collections.singletonList("자,110000000X"));
+		Assert.assertNotNull(DictionaryUtil.getWord("자"));
+		Assert.assertEquals(
+				"[저작자(N),는(j), 저작자는(N)][저작물(N),을(j), 저작물을(N)][창작(N),하(t),ㄴ(e), 창작한(N)][자(V),를(e), 자(N),를(j)][말(N),하(t),ㄴ다(e), 말한다(N)]",
+				analyze(crumb));
+
+		DictionaryUtil.addWords(Arrays.asList("저작물,100000000X", "저작자,100000000X"));
+		Assert.assertNotNull(DictionaryUtil.getWord("저작자"));
+		Assert.assertNotNull(DictionaryUtil.getWord("저작물"));
+		Assert.assertEquals(
+				"[저작자(N),는(j)][저작물(N),을(j)][창작(N),하(t),ㄴ(e), 창작한(N)][자(V),를(e), 자(N),를(j)][말(N),하(t),ㄴ다(e), 말한다(N)]",
+				analyze(crumb));
+	}
+}

--- a/src/test/java/org/apache/lucene/analysis/ko/MorphAnalyzerMultiThreadTest.java
+++ b/src/test/java/org/apache/lucene/analysis/ko/MorphAnalyzerMultiThreadTest.java
@@ -24,7 +24,7 @@ public class MorphAnalyzerMultiThreadTest {
 
 	@Test
 	public void test() throws Exception {
-		testMultiThread(4);
+		testMultiThread(8);
 	}
 
 	protected void testMultiThread(int nThreads) throws InterruptedException, ExecutionException {
@@ -42,9 +42,14 @@ public class MorphAnalyzerMultiThreadTest {
 			});
 		}
 
-		List<T> tasks = new ArrayList<T>();
+		List<Callable<String>> tasks = new ArrayList<Callable<String>>();
 		for (int n = 0; n < nThreads; n++) {
-			tasks.add(new T());
+			tasks.add(new Callable<String>() {
+				public String call() {
+					// DictionaryUtil.loadDictionary(false);
+					return exec();
+				}
+			});
 		}
 		List<Future<String>> results = pool.invokeAll(tasks);
 		for (Future<String> result : results) {
@@ -70,13 +75,5 @@ public class MorphAnalyzerMultiThreadTest {
 		} catch (Throwable e) {
 			throw new RuntimeException(e);
 		}
-	}
-
-	private class T implements Callable<String> {
-
-		public String call() {
-			return exec();
-		}
-
 	}
 }

--- a/src/test/java/org/apache/lucene/analysis/ko/MorphAnalyzerMultiThreadTest.java
+++ b/src/test/java/org/apache/lucene/analysis/ko/MorphAnalyzerMultiThreadTest.java
@@ -11,6 +11,7 @@ import java.util.logging.Logger;
 
 import org.apache.lucene.analysis.ko.morph.AnalysisOutput;
 import org.apache.lucene.analysis.ko.morph.MorphAnalyzer;
+import org.apache.lucene.analysis.ko.morph.MorphException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -61,19 +62,23 @@ public class MorphAnalyzerMultiThreadTest {
 
 	protected String exec() {
 		try {
-			MorphAnalyzer analyzer = new MorphAnalyzer();
-			StringBuilder buf = new StringBuilder();
 			log.info(Thread.currentThread().getName() + "analyze 시작");
-			for (int ii = 0; ii < crumb.length; ii++) {
-				List<AnalysisOutput> output = analyzer.analyze(crumb[ii]);
-				buf.append(output.toString());
-			}
-			String result = buf.toString();
+			String result = analyze(crumb);
 			log.info(Thread.currentThread().getName() + "analyze 종료");
 			return result;
-
 		} catch (Throwable e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	protected static String analyze(String[] crumb) throws MorphException {
+		MorphAnalyzer analyzer = new MorphAnalyzer();
+		StringBuilder buf = new StringBuilder();
+		
+		for (int ii = 0; ii < crumb.length; ii++) {
+			List<AnalysisOutput> output = analyzer.analyze(crumb[ii]);
+			buf.append(output.toString());
+		}
+		return buf.toString();
 	}
 }

--- a/src/test/java/org/apache/lucene/analysis/ko/MorphAnalyzerMultiThreadTest.java
+++ b/src/test/java/org/apache/lucene/analysis/ko/MorphAnalyzerMultiThreadTest.java
@@ -1,0 +1,82 @@
+package org.apache.lucene.analysis.ko;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+import org.apache.lucene.analysis.ko.morph.AnalysisOutput;
+import org.apache.lucene.analysis.ko.morph.MorphAnalyzer;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MorphAnalyzerMultiThreadTest {
+
+	private Logger log = Logger.getLogger(getClass().getName());
+
+	private static final String TEST = "저작자는 저작물을 창작한 자를 말한다";
+	private static final String[] crumb = TEST.split("\\s+");
+	private static final String EXPECT = "[저작자(N),는(j)][저작물(N),을(j)][창작(N),하(t),ㄴ(e)][자(V),를(e), 자르(V),ㄹ(e), 자(N),를(j)][말(N),하(t),ㄴ다(e)]";
+
+	@Test
+	public void test() throws Exception {
+		testMultiThread(4);
+	}
+
+	protected void testMultiThread(int nThreads) throws InterruptedException, ExecutionException {
+		ExecutorService pool = Executors.newFixedThreadPool(nThreads);
+		// 워밍업이 필요한가?
+		for (int n = 0; n < nThreads; n++) {
+			pool.submit(new Runnable() {
+				public void run() {
+					try {
+						Thread.sleep(100);
+					} catch (InterruptedException e) {
+						log.warning(e.getMessage());
+					}
+				}
+			});
+		}
+
+		List<T> tasks = new ArrayList<T>();
+		for (int n = 0; n < nThreads; n++) {
+			tasks.add(new T());
+		}
+		List<Future<String>> results = pool.invokeAll(tasks);
+		for (Future<String> result : results) {
+			Assert.assertEquals(EXPECT, result.get());
+		}
+
+		pool.shutdown();
+	}
+
+	protected String exec() {
+		try {
+			MorphAnalyzer analyzer = new MorphAnalyzer();
+			StringBuilder buf = new StringBuilder();
+			log.info(Thread.currentThread().getName() + "analyze 시작");
+			for (int ii = 0; ii < crumb.length; ii++) {
+				List<AnalysisOutput> output = analyzer.analyze(crumb[ii]);
+				buf.append(output.toString());
+			}
+			String result = buf.toString();
+			log.info(Thread.currentThread().getName() + "analyze 종료");
+			return result;
+
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private class T implements Callable<String> {
+
+		public String call() {
+			return exec();
+		}
+
+	}
+}


### PR DESCRIPTION
* 멀티쓰레드에서 사전을 한번만 로드하도록 수정 
[MorphAnalyzerMultiThreadTest.java](https://github.com/ddoleye/arirang.morph/blob/f40bd27dc5655bd44b1872b49bef7dfad94650d3/src/test/java/org/apache/lucene/analysis/ko/MorphAnalyzerMultiThreadTest.java)
* 단어 사전을 변경하는 (실험적인) 기능
[EmptyDictionaryTest.java](https://github.com/ddoleye/arirang.morph/blob/f40bd27dc5655bd44b1872b49bef7dfad94650d3/src/test/java/org/apache/lucene/analysis/ko/EmptyDictionaryTest.java)

```java
DictionaryUtil.initDictionary();

String TEST = "저작자는 저작물을 창작한 자를 말한다";
String[] crumb = TEST.split("\\s+");
Assert.assertEquals(
		"[저작자(N),는(j), 저작자는(N)][저작물(N),을(j), 저작물을(N)][창작(N),하(t),ㄴ(e), 창작한(N)][자(N),를(j), 자를(N)][말(N),하(t),ㄴ다(e), 말한다(N)]",
		analyze(crumb));

DictionaryUtil.addWords(Collections.singletonList("자,110000000X"));
Assert.assertEquals(
		"[저작자(N),는(j), 저작자는(N)][저작물(N),을(j), 저작물을(N)][창작(N),하(t),ㄴ(e), 창작한(N)][자(V),를(e), 자(N),를(j)][말(N),하(t),ㄴ다(e), 말한다(N)]",
		analyze(crumb));

DictionaryUtil.addWords(Arrays.asList("저작물,100000000X", "저작자,100000000X"));
Assert.assertEquals(
		"[저작자(N),는(j)][저작물(N),을(j)][창작(N),하(t),ㄴ(e), 창작한(N)][자(V),를(e), 자(N),를(j)][말(N),하(t),ㄴ다(e), 말한다(N)]",
		analyze(crumb));
```
